### PR TITLE
feat: update Node.js version and publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish Package
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v3
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "20"
+                  registry-url: "https://registry.npmjs.org"
+
+            - name: Install pnpm
+              run: npm install -g pnpm
+
+            - name: Install Dependencies
+              run: pnpm install
+
+            - name: Build Package
+              run: pnpm run build
+
+            - name: Publish to npm
+              run: pnpm publish --access public --no-git-checks
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT
+
+Copyright (c) 2025-present, Carlos Rivera
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+THE ABOVE COPYRIGHT NOTICE AND THIS PERMISSION NOTICE SHALL BE INCLUDED IN ALL
+COPIES OR SUBSTANTIAL PORTIONS OF THE SOFTWARE.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This commit updates the Node.js version in the publish workflow to version 20 and modifies the publish command.

The previous Node.js version (16) is outdated. Updating to version 20 ensures compatibility with newer features and security updates. Additionally, the `pnpm publish` command was updated to include the `--no-git-checks` flag to prevent issues during the publish process in the CI environment.

-   **Node.js Version**: Updated Node.js version from 16 to 20.
-   **Publish Command**: Modified the publish command to include `--no-git-checks`.

-   **Updated Node Version**: Changed `node-version` in `.github/workflows/publish.yml`.
-   **Modified Publish Command**: Added `--no-git-checks` to `pnpm publish` in `.github/workflows/publish.yml`.

-   `.github/workflows/publish.yml`