### PR TITLE
chore: install @types/react as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@types/react": "^19.0.8",
     "@vitejs/plugin-react": "^4.3.4",
     "husky": "^9.1.7",
     "lint-staged": "^15.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^3.24.1
         version: 3.24.1
     devDependencies:
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.0.8
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.1.0(yaml@2.7.0))
@@ -453,6 +456,9 @@ packages:
   '@types/gensync@1.0.4':
     resolution: {integrity: sha512-C3YYeRQWp2fmq9OryX+FoDy8nXS6scQ7dPptD8LnFDAUNcKWJjXQKDNJD3HVm+kOUsXhTOkpi69vI4EuAr95bA==}
 
+  '@types/react@19.0.8':
+    resolution: {integrity: sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==}
+
   '@vitejs/plugin-react@4.3.4':
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -588,6 +594,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -1456,6 +1465,10 @@ snapshots:
 
   '@types/gensync@1.0.4': {}
 
+  '@types/react@19.0.8':
+    dependencies:
+      csstype: 3.1.3
+
   '@vitejs/plugin-react@4.3.4(vite@6.1.0(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.26.8
@@ -1602,6 +1615,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.1.3: {}
 
   de-indent@1.0.2: {}
 


### PR DESCRIPTION
This commit installs `@types/react` as a development dependency.

`@types/react` provides TypeScript definitions for React.  Installing this package improves type checking and autocompletion when working with React in a TypeScript project. It enhances the development experience and helps catch potential errors early. It was not previously a dependency.

-   **Added Dependency**: Installed `@types/react` using `pnpm add -D @types/react`.

-   **Install @types/react**: Executed the command to add the package as a dev dependency.

-   `package.json` (implicitly, by updating devDependencies)
-   `pnpm-lock.yaml` (implicitly, by updating the lockfile)