### PR TITLE
chore: bump version on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,19 @@ jobs:
             - name: Install pnpm
               run: npm install -g pnpm
 
+            - name: Bump version
+              run: |
+                  # Configure git user for the commit
+                  git config user.name "github-actions"
+                  git config user.email "github-actions@github.com"
+                  # Bump the version (patch increment) and commit with [skip ci] to avoid triggering a new workflow run.
+                  npm version patch -m "chore: bump version to %s [skip ci]"
+              env:
+                  CI: true
+
+            - name: Push version bump commit and tags
+              run: git push origin HEAD --follow-tags
+
             - name: Install Dependencies
               run: pnpm install
 


### PR DESCRIPTION
This commit adds steps to automatically bump the package version and push the commit and tags during the publish workflow.

Automating the version bump process ensures that every publish to npm has a new version number, preventing accidental overwrites and maintaining a clean version history. The `[skip ci]` tag in the commit message prevents triggering another workflow run when the version is bumped.

-   **Added Version Bump Step**: Included commands to configure git user and bump the version using `npm version patch`.
-   **Added Push Commit and Tags Step**: Added a command to push the commit and tags to the remote repository.

-   **Configure Git User**: Set `user.name` and `user.email` for git.
-   **Bump Version**: Used `npm version patch` to increment the patch version and create a commit.
- **Push Changes**: Pushed the commit and tags using `git push origin HEAD --follow-tags`.

-   `.github/workflows/publish.yml`