### PR TITLE
fix: authenticate git push with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,12 @@ jobs:
                   CI: true
 
             - name: Push version bump commit and tags
-              run: git push origin HEAD --follow-tags
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  # Set the remote URL to include the authentication token
+                  git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/hacktails/kpathdb.git
+                  git push origin HEAD --follow-tags
 
             - name: Install Dependencies
               run: pnpm install


### PR DESCRIPTION
This commit updates the "Push version bump commit and tags" step in the publish workflow to authenticate the `git push` command using a Personal Access Token (PAT) via the `GITHUB_TOKEN` secret.

The previous configuration, which did not explicitly set the remote with authentication, was likely failing to push the version bump commit and tags due to authentication issues. By setting the remote URL to include the `GITHUB_TOKEN`, we ensure that the `git push` command has the necessary permissions to push to the repository. This is necessary for the automated version bumping and publishing process to succeed.

- **Set Remote URL with Token**: Added `git remote set-url origin` to include the `GITHUB_TOKEN` in the remote URL.
- **Added GITHUB_TOKEN env**: Added the GITHUB_TOKEN to the env of the step.

-   **Modified Git Push Command**: Updated the command to use an authenticated remote URL.

-   `.github/workflows/publish.yml`