### PR TITLE
fix: use PAT for git authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
 
             - name: Push version bump commit and tags
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.PAT }}
               run: |
                   # Set the remote URL to include the authentication token
                   git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/hacktails/kpathdb.git


### PR DESCRIPTION
This commit changes the `GITHUB_TOKEN` environment variable to use `secrets.PAT` instead of `secrets.GITHUB_TOKEN` in the "Push version bump commit and tags" step of the publish workflow.

Using a Personal Access Token (PAT) with appropriate permissions is generally recommended over the default `GITHUB_TOKEN` for actions that require write access to the repository, such as pushing commits and tags. The `GITHUB_TOKEN` has limited scope, and using a PAT provides more granular control over permissions. It appears from a prior diff that we switched to using `secrets.PAT`.

- **Updated Environment Variable**: Changed `GITHUB_TOKEN` to use `secrets.PAT`.

- **Switched to PAT**: Replaced `secrets.GITHUB_TOKEN` with `secrets.PAT`.

-   `.github/workflows/publish.yml`